### PR TITLE
Bumping `pyngrok` to 5.x.x, Fixing Breaking Change

### DIFF
--- a/flask_pyngrok/__init__.py
+++ b/flask_pyngrok/__init__.py
@@ -20,7 +20,7 @@ class PyNgrok(object):
                 if "--port" in sys.argv
                 else 5000  # noqa
             )
-            public_url = ngrok.connect(port)
+            public_url = ngrok.connect(port).public_url
             print(
                 ' * ngrok tunnel "{}" -> "http://127.0.0.1:{}/"'.format(
                     public_url, port

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask>=1.1.2
-pyngrok>=3.1.0
+pyngrok>=5.0.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="Flask-PyNgrok",
-    version="1.0.3",
+    version="1.1.0",
     url="https://github.com/sidshrivastav/Flask-PyNgrok",
     license="MIT",
     author="Siddhant Shrivastav",
@@ -23,7 +23,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms="any",
-    install_requires=["Flask", "pyngrok"],
+    install_requires=["Flask", "pyngrok>=5.0.0"],
     classifiers=[
         "Environment :: Web Environment",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms="any",
+    python_requires=">=3.5",
     install_requires=["Flask", "pyngrok>=5.0.0"],
     classifiers=[
         "Environment :: Web Environment",


### PR DESCRIPTION
- Without pinning, Flask-PyNgrok will be broken given the changes in `pyngrok` 5.0.0.
- Bumped `pyngrok`, pinned relative version, and fixed compatibility issues.